### PR TITLE
Add simple Express organigram web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # OrganigramApp
-Aplicación Web y Movil para crear los organigramas de empresas.
+
+Aplicación Web para crear organigramas de empresas. Esta versión incluye un pequeño servidor Express y una interfaz web que permite agregar empleados y visualizar la estructura jerárquica.
+
+## Requisitos
+
+- Node.js 20 o superior
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Uso
+
+```bash
+node server.js
+```
+
+El servidor se iniciará en `http://localhost:3000`. Accede a esa URL en tu navegador para comenzar a agregar empleados y generar el organigrama de la empresa.
+
+La información se almacena en memoria, por lo que se perderá al detener el servidor.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "organigramapp",
+  "version": "1.0.0",
+  "description": "Aplicación Web y Movil para crear los organigramas de empresas.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests defined\"",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Organigrama</title>
+  <style>
+    #chart {
+      width: 100%;
+      height: 500px;
+      border: 1px solid #ccc;
+    }
+    form {
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Organigrama de la Empresa</h1>
+  <form id="employeeForm">
+    <input type="text" id="name" placeholder="Nombre" required>
+    <input type="number" id="managerId" placeholder="ID del Jefe (opcional)">
+    <button type="submit">Agregar</button>
+  </form>
+  <div id="chart"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,104 @@
+async function fetchEmployees() {
+  const res = await fetch('/api/employees');
+  return res.json();
+}
+
+async function addEmployee(name, managerId) {
+  await fetch('/api/employees', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, managerId: managerId ? Number(managerId) : null })
+  });
+}
+
+function createHierarchy(data) {
+  const map = new Map();
+  data.forEach(emp => map.set(emp.id, { ...emp, children: [] }));
+  let root = null;
+  data.forEach(emp => {
+    const node = map.get(emp.id);
+    if (emp.managerId) {
+      const manager = map.get(emp.managerId);
+      if (manager) manager.children.push(node);
+    } else {
+      root = node;
+    }
+  });
+  return root;
+}
+
+function renderChart(rootData) {
+  d3.select('#chart').selectAll('*').remove();
+  const width = document.getElementById('chart').clientWidth;
+  const dx = 10;
+  const dy = width / 6;
+  const tree = d3.tree().nodeSize([dx, dy]);
+  const root = d3.hierarchy(rootData);
+  tree(root);
+
+  let x0 = Infinity;
+  let x1 = -x0;
+  root.each(d => {
+    if (d.x > x1) x1 = d.x;
+    if (d.x < x0) x0 = d.x;
+  });
+
+  const svg = d3.select('#chart')
+    .append('svg')
+    .attr('viewBox', [0, 0, width, x1 - x0 + dx * 2])
+    .style('font', '10px sans-serif');
+
+  const g = svg.append('g')
+    .attr('transform', `translate(${dy / 3},${dx - x0})`);
+
+  const link = g.append('g')
+    .attr('fill', 'none')
+    .attr('stroke', '#555')
+    .attr('stroke-opacity', 0.4)
+    .attr('stroke-width', 1.5)
+    .selectAll('path')
+    .data(root.links())
+    .join('path')
+    .attr('d', d3.linkHorizontal()
+      .x(d => d.y)
+      .y(d => d.x));
+
+  const node = g.append('g')
+    .attr('stroke-linejoin', 'round')
+    .attr('stroke-width', 3)
+    .selectAll('g')
+    .data(root.descendants())
+    .join('g')
+    .attr('transform', d => `translate(${d.y},${d.x})`);
+
+  node.append('circle')
+    .attr('fill', d => d.children ? '#555' : '#999')
+    .attr('r', 5);
+
+  node.append('text')
+    .attr('dy', '0.31em')
+    .attr('x', d => d.children ? -6 : 6)
+    .attr('text-anchor', d => d.children ? 'end' : 'start')
+    .text(d => d.data.name)
+    .clone(true).lower()
+    .attr('stroke', 'white');
+}
+
+async function refresh() {
+  const data = await fetchEmployees();
+  if (!data.length) return;
+  const root = createHierarchy(data);
+  renderChart(root);
+}
+
+refresh();
+
+const form = document.getElementById('employeeForm');
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const name = document.getElementById('name').value;
+  const managerId = document.getElementById('managerId').value;
+  await addEmployee(name, managerId);
+  form.reset();
+  refresh();
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const path = require('path');
+const bodyParser = require('body-parser');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(bodyParser.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// In-memory store of employees
+let employees = [];
+
+// Add employee { id, name, managerId }
+app.post('/api/employees', (req, res) => {
+  const { name, managerId } = req.body;
+  const id = employees.length + 1;
+  employees.push({ id, name, managerId: managerId || null });
+  res.json({ id });
+});
+
+// Get all employees
+app.get('/api/employees', (req, res) => {
+  res.json(employees);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- create an Express server with in-memory employee data
- add front-end HTML/JS to add employees and visualize the org chart via D3
- document installation and usage instructions in Spanish
- provide package.json with start and test scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f8be0429c8333883d56eafbb66c70